### PR TITLE
Show falsy default values in help

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -2,6 +2,7 @@ import * as Config from '@oclif/config'
 import chalk from 'chalk'
 import indent = require('indent-string')
 import stripAnsi = require('strip-ansi')
+import util = require('util')
 
 import {HelpOptions} from '.'
 import {renderList} from './list'
@@ -95,7 +96,7 @@ export default class CommandHelp {
     let body = renderList(args.map(a => {
       const name = a.name.toUpperCase()
       let description = a.description || ''
-      if (a.default) description = `[default: ${a.default}] ${description}`
+      if (a.default !== undefined) description = `[default: ${util.inspect(a.default)}] ${description}`
       if (a.options) description = `(${a.options.join('|')}) ${description}`
       return [name, description ? dim(description) : undefined]
     }), {stripAnsi: this.opts.stripAnsi, maxWidth: this.opts.maxWidth - 2})
@@ -133,8 +134,8 @@ export default class CommandHelp {
       }
 
       let right = flag.description || ''
-      if (flag.type === 'option' && flag.default) {
-        right = `[default: ${flag.default}] ${right}`
+      if (flag.type === 'option' && flag.default !== undefined) {
+        right = `[default: ${util.inspect(flag.default)}] ${right}`
       }
       if (flag.required) right = `(required) ${right}`
 

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -165,13 +165,13 @@ OPTIONS
   $ oclif apps:create [ARG1] [ARG2] [ARG3]
 
 ARGUMENTS
-  ARG1  [default: .]
-  ARG2  [default: .] arg2 desc
+  ARG1  [default: '.']
+  ARG2  [default: '.'] arg2 desc
   ARG3  arg3 desc
 
 OPTIONS
-  --flag1=flag1  [default: .]
-  --flag2=flag2  [default: .] flag2 desc
+  --flag1=flag1  [default: '.']
+  --flag2=flag2  [default: '.'] flag2 desc
   --flag3=flag3  flag3 desc`))
 
   test


### PR DESCRIPTION
Closes oclif/oclif#192.

The downside of this is that it makes string defaults more "verbose", as you can see in the updated tests.