### PR TITLE
feat: allow templates in usage and provide command context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,8 +113,8 @@ export default class Help {
   }
 
   command(command: Config.Command): string {
-    const help = new CommandHelp(this.config, this.opts)
-    return help.command(command)
+    const help = new CommandHelp(command, this.config, this.opts)
+    return help.generate()
   }
 
   topics(topics: Config.Topic[]): string | undefined {

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -200,6 +200,23 @@ ARGUMENTS
 OPTIONS
   --[no-]opt`))
 
+  test
+    .commandHelp(class extends Command {
+      static id = 'apps:create'
+      static usage = '<%= config.bin %> <%= command.id %> usage'
+    })
+    .it('outputs usage with templates', ctx => expect(ctx.commandHelp).to.equal(`USAGE
+  $ oclif oclif apps:create usage`))
+
+  test
+    .commandHelp(class extends Command {
+      static id = 'apps:create'
+      static usage = ['<%= config.bin %>', '<%= command.id %> usage']
+    })
+    .it('outputs usage arrays with templates', ctx => expect(ctx.commandHelp).to.equal(`USAGE
+  $ oclif oclif
+  $ oclif apps:create usage`))
+
   // class AppsCreate3 extends Command {
   //   static id = 'apps:create'
   //   static flags = {


### PR DESCRIPTION
When writing custom usage strings, it would be nice to still include the command name, but there is no way to currently do that. This PR provides a way to template usage strings and provides the command as an variable to template.