### PR TITLE
separate topic-commands and topics in help output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,18 +119,56 @@ export default class Help {
 
   topics(topics: Config.Topic[]): string | undefined {
     if (!topics.length) return
-    let body = renderList(topics.map(c => [
-      c.name,
-      c.description && this.render(c.description.split('\n')[0])
-    ]), {
+
+    let Topics: Array<string | undefined>[] = []
+    let Commands: Array<string | undefined>[] = []
+
+    topics.map(t => {
+      let out = [
+        t.name,
+        t.description && this.render(t.description.split('\n')[0])
+      ]
+      if (this.config.commandIDs.includes(t.name)) {
+        Commands.push(out)
+      }
+      let tp = this.config.commandIDs.find(id => {
+        if (id.match(`${t.name}:`)) return true
+        return false
+      })
+      if (tp) {
+        Topics.push(out)
+      }
+    })
+
+    let commandsList = renderList(Commands, {
       spacer: '\n',
       stripAnsi: this.opts.stripAnsi,
       maxWidth: this.opts.maxWidth - 2,
     })
-    return [
-      bold('COMMANDS'),
-      indent(body, 2),
-    ].join('\n')
+
+    let output = [
+      [
+        bold('COMMANDS'),
+        indent(commandsList, 2),
+      ].join('\n')
+    ]
+
+    if (Topics.length) {
+      let topicsList = renderList(Topics, {
+        spacer: '\n',
+        stripAnsi: this.opts.stripAnsi,
+        maxWidth: this.opts.maxWidth - 2,
+      })
+      output.push(
+        [
+          bold('TOPICS'),
+          indent('Run help for each topic below to view its subcommands\n', 2),
+          indent(topicsList, 2),
+        ].join('\n')
+      )
+    }
+
+    return output.join('\n\n')
   }
 }
 

--- a/test/commands/help.test.ts
+++ b/test/commands/help.test.ts
@@ -63,6 +63,11 @@ COMMANDS
   help     display help for oclif
   plugins  list installed plugins
 
+TOPICS
+  Run help for each topic below to view its subcommands
+
+  plugins  list installed plugins
+
 `)
     })
 })


### PR DESCRIPTION
WIP/spike do not review or merge

pros:
- shows topic-commands and topics in separate lists to clarify them as separate objects/concepts
- doesn't mess with `config.Topics`

cons:
- uses topic's help description, ignoring topic-command's help description (topic-command's help description would have to be found/looked up)  
- better to handle this in config?