### PR TITLE
Update lodash.template

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@oclif/command": "^1.5.13",
     "chalk": "^2.4.1",
     "indent-string": "^3.2.0",
-    "lodash.template": "^4.4.0",
+    "lodash.template": "4.5.0",
     "string-width": "^3.0.0",
     "strip-ansi": "^5.0.0",
     "widest-line": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,10 +1404,18 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash._reinterpolate@~3.0.0:
+lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
+lodash.template@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
+  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
+    lodash.templatesettings "^4.0.0"
 
 lodash.template@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
I received a security alert for the lodash.template dependency,
indicating that it was potentially vulnerable to prototype
pollution.  Updating to v4.5.0 or above was recommended as the
fix.