### PR TITLE
chore: update `indent-string` to `^4.0.0` (from `^3.2.0`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@oclif/command": "^1.5.13",
     "chalk": "^2.4.1",
-    "indent-string": "^3.2.0",
+    "indent-string": "^4.0.0",
     "lodash.template": "^4.4.0",
     "string-width": "^3.0.0",
     "strip-ansi": "^5.0.0",
@@ -22,7 +22,6 @@
     "@oclif/plugin-plugins": "^1.7.6",
     "@oclif/test": "^1.2.2",
     "@types/chai": "^4.1.7",
-    "@types/indent-string": "^3.2.0",
     "@types/lodash.template": "^4.4.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.59",

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,11 +220,6 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/indent-string@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@types/indent-string/-/indent-string-3.2.0.tgz#ce0016b6527a582e98122d593000772a965db665"
-  integrity sha512-9iJXKl51MSjBOO8AWJyDtegBy4PkcgwIQCNYmHA63qtYlaISD6sEcB4jZ8APOdBacZJ8fZwxZpN7iwYlyE6eGw==
-
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -1498,6 +1493,11 @@ indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
This removes the need for `@types/indent-string`, and allows better deduplication.