### PR TITLE
Support default command feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@oclif/command": "^1.5.13",
     "chalk": "^2.4.1",
+    "escape-string-regexp": "^2.0.0",
     "indent-string": "^4.0.0",
     "lodash.template": "^4.4.0",
     "string-width": "^3.0.0",

--- a/src/command.ts
+++ b/src/command.ts
@@ -69,7 +69,6 @@ export default class CommandHelp {
       const commandRegex = new RegExp(`^(.*(?:\\b${
         binEscaped
       }|<%=\\s*config\\.bin\\s*%>)\\s*.*\\s)(<%=\\s*command\\.id\\s*%>|${commandEscaped})(\\s+|$)`)
-      console.log(commandRegex)
       const transformedCommandName = this.transformCommandName(defaultCommandId, usageOptions)
       result = usages.map(usage => {
         const groups = commandRegex.exec(usage)

--- a/src/command.ts
+++ b/src/command.ts
@@ -59,7 +59,7 @@ export default class CommandHelp {
     return output
   }
 
-  transformUsages(usages: string[], usageOptions?: UsageOptions) {
+  protected transformUsages(usages: string[], usageOptions?: UsageOptions) {
     usageOptions = usageOptions || {}
     let result = usages
     const defaultCommandId = getDefaultCommandId(this.config)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
 import lodashTemplate = require('lodash.template')
+import * as Config from '@oclif/config'
+import Help from '.'
 
 export function uniqBy<T>(arr: T[], fn: (cur: T) => any): T[] {
   return arr.filter((a, i) => {
@@ -45,4 +47,12 @@ export function template(context: any): (t: string) => string {
     return lodashTemplate(t)(context)
   }
   return render
+}
+
+export function getDefaultCommandId(config: Config.IConfig) {
+  return (config.pjson.oclif as {defaultCommand?: string}).defaultCommand
+}
+
+export function getUsagePrefix(config: Config.IConfig, opts: Help['opts']) {
+  return opts.usagePrefix === undefined ? `$ ${config.bin} ` : opts.usagePrefix
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,6 +881,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 eslint-ast-utils@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz#3d58ba557801cfb1c941d68131ee9f8c34bd1586"


### PR DESCRIPTION
https://github.com/oclif/oclif/issues/277

* show (default) next to default command in help command list
* show [\<defaultCommand\>] as optional in default command usage
* show default command usages in the main help page USAGE section (with command name omitted)
* omit command name in default command EXAMPLE section