### PR TITLE
fix: @oclif/errors should be a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1.15.1",
+    "@oclif/errors": "^1.2.2",
     "chalk": "^2.4.1",
     "indent-string": "^4.0.0",
     "lodash.template": "^4.4.0",
@@ -17,7 +18,6 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.0",
-    "@oclif/errors": "^1.2.2",
     "@oclif/plugin-legacy": "^1.1.3",
     "@oclif/plugin-plugins": "^1.7.6",
     "@oclif/test": "^1.2.2",


### PR DESCRIPTION
Since `@oclif/errors` is required from `index.ts` (see below), it should be modeled as a direct `dependency` and not as a `devDependency`. In the current state of things, it is not possible to use this library with `yarn` 2, as this produces the following error:

```
Error: @oclif/plugin-help tried to access @oclif/errors, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @oclif/errors (via "@oclif/errors")
Required by: @oclif/plugin-help@npm:3.2.0 (via <redacted>/.yarn/cache/@oclif-plugin-help-npm-3.2.0-94fac21a1a-d42ba4b5f0.zip/node_modules/@oclif/plugin-help/lib/)
```

https://github.com/oclif/plugin-help/blob/9c7b287980ea4fb3a42eea9f9aa3c2d31d25e309/src/index.ts#L2