### PR TITLE
fix: move oclif/errors to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1.15.1",
+    "@oclif/errors": "^1.2.2",
     "chalk": "^2.4.1",
     "indent-string": "^4.0.0",
     "lodash.template": "^4.4.0",
@@ -17,7 +18,6 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.0",
-    "@oclif/errors": "^1.2.2",
     "@oclif/plugin-legacy": "^1.1.3",
     "@oclif/plugin-plugins": "^1.7.6",
     "@oclif/test": "^1.2.2",


### PR DESCRIPTION
This package is actually used by the published library code, so it should be a dependency