### PR TITLE
fix: render default arg/opt if equal to 0

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -100,7 +100,7 @@ export default class CommandHelp {
     const body = renderList(args.map(a => {
       const name = a.name.toUpperCase()
       let description = a.description || ''
-      if (a.default) description = `[default: ${a.default}] ${description}`
+      if (a.default !== '' && a.default !== undefined) description = `[default: ${a.default}] ${description}`
       if (a.options) description = `(${a.options.join('|')}) ${description}`
       return [name, description ? dim(description) : undefined]
     }), {stripAnsi: this.opts.stripAnsi, maxWidth: this.opts.maxWidth - 2})
@@ -144,7 +144,7 @@ export default class CommandHelp {
       }
 
       let right = flag.description || ''
-      if (flag.type === 'option' && flag.default) {
+      if (flag.type === 'option' && flag.default !== '' && flag.default !== undefined) {
         right = `[default: ${flag.default}] ${right}`
       }
       if (flag.required) right = `(required) ${right}`


### PR DESCRIPTION
This PR fixes rendering of default values for arguments and flags.
Before the fix, if an arg/flag default was set to 0, it was not rendered.

I couldn't reopen or edit my existing PR, so this is an updated version of #248, but the base branch is set to `main` this time.