### PR TITLE
Update wrap-ansi to major 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",
     "widest-line": "^3.1.0",
-    "wrap-ansi": "^4.0.0"
+    "wrap-ansi": "^6.2.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.1",

--- a/src/list.ts
+++ b/src/list.ts
@@ -16,12 +16,12 @@ export function renderList(input: (string | undefined)[][], opts: {maxWidth: num
       if (!left && !right) continue
       if (left) {
         if (opts.stripAnsi) left = stripAnsi(left)
-        output += wrap(left.trim(), opts.maxWidth, {hard: true, trim: false})
+        output += wrap(left.trim(), opts.maxWidth, {hard: true, trim: true})
       }
       if (right) {
         if (opts.stripAnsi) right = stripAnsi(right)
         output += '\n'
-        output += indent(wrap(right.trim(), opts.maxWidth - 2, {hard: true, trim: false}), 4)
+        output += indent(wrap(right.trim(), opts.maxWidth - 2, {hard: true, trim: true}), 4)
       }
       output += '\n\n'
     }
@@ -45,7 +45,7 @@ export function renderList(input: (string | undefined)[][], opts: {maxWidth: num
       continue
     }
     if (opts.stripAnsi) right = stripAnsi(right)
-    right = wrap(right.trim(), opts.maxWidth - (maxLength + 2), {hard: true, trim: false})
+    right = wrap(right.trim(), opts.maxWidth - (maxLength + 2), {hard: true, trim: true})
     // right = wrap(right.trim(), screen.stdtermwidth - (maxLength + 4), {hard: true, trim: false})
     const [first, ...lines] = right!.split('\n').map(s => s.trim())
     cur += ' '.repeat(maxLength - width(cur) + 2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2927,6 +2927,15 @@ wrap-ansi@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"


### PR DESCRIPTION
Alternative to [dependabot PR](https://github.com/oclif/plugin-help/pull/293) for `wrap-ansi` which updates to major 8. This version however [only exposes ESM](https://github.com/chalk/wrap-ansi/releases/tag/v8.0.0). While good to consume that newer major eventually it could involve more extensive changes (mocha and/or typescript config updates).

This PR hopefully is good to merge and successfully passes CI.

Fixes #310

